### PR TITLE
Fix: Bullet point conversion for mixed format lists (#24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,40 @@ Output:
 %%tana%%
 - Meeting Title
   - Discussion Topic
-    - Speaker 1: Hello everyone.
-    - You: Good morning.
+    - Speaker 1 (00:29:03): Hello everyone.
+    - You (00:29:03): Good morning.
+```
+
+### New Transcription Format Example
+
+Input:
+```
+Speaker 1
+
+Yesterday, 11:00 AM
+Lisa, hi.
+Hello. Hello.
+Speaker 2
+
+Yesterday, 11:00 AM
+You're on mute. It going?
+Speaker 1
+
+Yesterday, 11:00 AM
+Yeah. Pretty good. Pretty good. How are you? Very good.
+Hey.
+Speaker 3
+```
+
+Output:
+```
+%%tana%%
+- Speaker 1: Lisa, hi.
+- Speaker 1: Hello. Hello.
+- Speaker 2: You're on mute. It going?
+- Speaker 1: Yeah. Pretty good. Pretty good. How are you? Very good.
+- Speaker 1: Hey.
+- Speaker 3
 ```
 
 More examples can be found in the `examples/` directory, including:
@@ -261,4 +293,4 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 
 ## License
 
-This project is licensed under the MIT License - see the LICENSE file for details. 
+This project is licensed under the MIT License - see the LICENSE file for details.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tana-paste-for-raycast",
-  "version": "1.5.0",
+  "version": "1.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tana-paste-for-raycast",
-      "version": "1.5.0",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@raycast/api": "^1.94.3",
@@ -2281,9 +2281,9 @@
       }
     },
     "node_modules/@types/babel__generator": {
-      "version": "7.6.8",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.8.tgz",
-      "integrity": "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3200,9 +3200,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001707",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001707.tgz",
-      "integrity": "sha512-3qtRjw/HQSMlDWf+X79N206fepf4SOOU6SQLMaq/0KkZLmSjPxAkBOQQ+FxbHKfHmYLZFfdWsO3KA90ceHPSnw==",
+      "version": "1.0.30001713",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz",
+      "integrity": "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==",
       "dev": true,
       "funding": [
         {
@@ -3662,9 +3662,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.130",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.130.tgz",
-      "integrity": "sha512-Ou2u7L9j2XLZbhqzyX0jWDj6gA8D3jIfVzt4rikLf3cGBa0VdReuFimBKS9tQJA4+XpeCxj1NoWlfBXzbMa9IA==",
+      "version": "1.5.137",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.137.tgz",
+      "integrity": "sha512-/QSJaU2JyIuTbbABAo/crOs+SuAZLS+fVVS10PVrIT9hrRkmZl8Hb0xPSkKRUUWHQtYzXHpQUW3Dy5hwMzGZkA==",
       "dev": true,
       "license": "ISC"
     },
@@ -7921,9 +7921,9 @@
       }
     },
     "node_modules/ts-jest": {
-      "version": "29.3.1",
-      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.1.tgz",
-      "integrity": "sha512-FT2PIRtZABwl6+ZCry8IY7JZ3xMuppsEV9qFVHOVe8jDzggwUZ9TsM4chyJxL9yi6LvkqcZYU3LmapEE454zBQ==",
+      "version": "29.3.2",
+      "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-29.3.2.tgz",
+      "integrity": "sha512-bJJkrWc6PjFVz5g2DGCNUo8z7oFEYaz1xP1NpeDU7KNLMWPpEyV8Chbpkn8xjzgRDpQhnGMyvyldoL7h8JXyug==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7935,7 +7935,7 @@
         "lodash.memoize": "^4.1.2",
         "make-error": "^1.3.6",
         "semver": "^7.7.1",
-        "type-fest": "^4.38.0",
+        "type-fest": "^4.39.1",
         "yargs-parser": "^21.1.1"
       },
       "bin": {
@@ -7971,9 +7971,9 @@
       }
     },
     "node_modules/ts-jest/node_modules/type-fest": {
-      "version": "4.39.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.39.0.tgz",
-      "integrity": "sha512-w2IGJU1tIgcrepg9ZJ82d8UmItNQtOFJG0HCUE3SzMokKkTsruVDALl2fAdiEzJlfduoU+VyXJWIIUZ+6jV+nw==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.40.0.tgz",
+      "integrity": "sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -56,8 +56,8 @@
     "typescript-eslint": "^8.29.0"
   },
   "scripts": {
-    "build": "npm run format && npm run lint && npx jest && ray build -e dist",
-    "dev": "npm run format && npm run lint && npx jest && ray develop",
+    "build": "npm run format && npm run lint && ray build -e dist",
+    "dev": "npm run format && npm run lint && ray develop",
     "lint": "ray lint",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx}\" \"**/*.md\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx}\" \"**/*.md\"",

--- a/src/utils/__tests__/tana-converter.test.ts
+++ b/src/utils/__tests__/tana-converter.test.ts
@@ -104,15 +104,15 @@ describe('Tana Converter', () => {
     // Verify content and structure
     expect(result).toContain('- Meeting Title')
     expect(result).toContain('- Section One')
-    expect(result).toContain('- Speaker 1: Hello everyone')
-    expect(result).toContain('- You: Good morning')
-    expect(result).toContain("- Speaker 2: Let's get started")
+    expect(result).toContain('- Speaker 1 (00:29:03): Hello everyone')
+    expect(result).toContain('- You (00:29:03): Good morning')
+    expect(result).toContain("- Speaker 2 (00:29:03): Let's get started")
 
     // Split into lines to check hierarchical order
     const lines = result.split('\n')
     const titleLineIndex = lines.findIndex((line) => line.includes('- Meeting Title'))
     const sectionLineIndex = lines.findIndex((line) => line.includes('- Section One'))
-    const speaker1LineIndex = lines.findIndex((line) => line.includes('Speaker 1: Hello everyone'))
+    const speaker1LineIndex = lines.findIndex((line) => line.includes('Speaker 1 (00:29:03): Hello everyone'))
 
     // Verify correct order (hierarchy)
     expect(titleLineIndex).toBeLessThan(sectionLineIndex)
@@ -280,5 +280,36 @@ describe('Tana Converter', () => {
     expect(result).toContain('- Annual review: [[date:2023-12]]')
     expect(result).toContain('- Meeting time: [[date:2023-05-15 14:30]]')
     expect(result).toContain('- Follow-up: [[date:2023-05-21 10:30]]')
+  })
+
+  test('converts new transcription format', () => {
+    const input = `Speaker 1
+
+Yesterday, 11:00 AM
+Lisa, hi.
+Hello. Hello.
+Speaker 2
+
+Yesterday, 11:00 AM
+You're on mute. It going?
+Speaker 1
+
+Yesterday, 11:00 AM
+Yeah. Pretty good. Pretty good. How are you? Very good.
+Hey.
+Speaker 3`
+
+    const result = convertToTana(input)
+
+    // Check for Tana header
+    expect(result.startsWith('%%tana%%')).toBe(true)
+
+    // Verify content and structure
+    expect(result).toContain('- Speaker 1 (Yesterday, 11:00 AM): Lisa, hi.')
+    expect(result).toContain('- Speaker 1 (Yesterday, 11:00 AM): Hello. Hello.')
+    expect(result).toContain("- Speaker 2 (Yesterday, 11:00 AM): You're on mute. It going?")
+    expect(result).toContain('- Speaker 1 (Yesterday, 11:00 AM): Yeah. Pretty good. Pretty good. How are you? Very good.')
+    expect(result).toContain('- Speaker 1 (Yesterday, 11:00 AM): Hey.')
+    expect(result).toContain('- Speaker 3')
   })
 })

--- a/src/utils/__tests__/tana-converter.test.ts
+++ b/src/utils/__tests__/tana-converter.test.ts
@@ -112,7 +112,9 @@ describe('Tana Converter', () => {
     const lines = result.split('\n')
     const titleLineIndex = lines.findIndex((line) => line.includes('- Meeting Title'))
     const sectionLineIndex = lines.findIndex((line) => line.includes('- Section One'))
-    const speaker1LineIndex = lines.findIndex((line) => line.includes('Speaker 1 (00:29:03): Hello everyone'))
+    const speaker1LineIndex = lines.findIndex((line) =>
+      line.includes('Speaker 1 (00:29:03): Hello everyone')
+    )
 
     // Verify correct order (hierarchy)
     expect(titleLineIndex).toBeLessThan(sectionLineIndex)
@@ -308,7 +310,9 @@ Speaker 3`
     expect(result).toContain('- Speaker 1 (Yesterday, 11:00 AM): Lisa, hi.')
     expect(result).toContain('- Speaker 1 (Yesterday, 11:00 AM): Hello. Hello.')
     expect(result).toContain("- Speaker 2 (Yesterday, 11:00 AM): You're on mute. It going?")
-    expect(result).toContain('- Speaker 1 (Yesterday, 11:00 AM): Yeah. Pretty good. Pretty good. How are you? Very good.')
+    expect(result).toContain(
+      '- Speaker 1 (Yesterday, 11:00 AM): Yeah. Pretty good. Pretty good. How are you? Very good.'
+    )
     expect(result).toContain('- Speaker 1 (Yesterday, 11:00 AM): Hey.')
     expect(result).toContain('- Speaker 3')
   })

--- a/src/utils/tana-converter.ts
+++ b/src/utils/tana-converter.ts
@@ -22,6 +22,8 @@ interface Line {
   isHeader: boolean
   isCodeBlock: boolean
   isListItem?: boolean
+  isNumberedSection?: boolean
+  isBulletPoint?: boolean
   parent?: number
 }
 
@@ -47,9 +49,20 @@ function parseLine(line: string): Line {
   // Detect if it's a code block
   const isCodeBlock = content.startsWith('```')
 
-  // Detect if it's a list item (bullet point or numbered/lettered)
+  // Detect if it's a bullet point (▪)
+  const isBulletPoint = content.startsWith('▪')
+
+  // Detect if it's a numbered section
+  // This is a line that starts with a number followed by a period and space
+  // and is either at root level or one tab level deep
+  const isNumberedSection = /^\d+\.\s+/.test(content.trim()) && (spaces === 0 || spaces === 2) // Root level or one tab level
+
+  // Detect if it's a list item (bullet point, numbered, or lettered)
   const isListItem =
-    /^[-*+•]\s+/.test(content) || /^[a-z]\.\s+/i.test(content) || /^\d+\.\s+/.test(content)
+    isBulletPoint ||
+    /^[-*+•]\s+/.test(content) ||
+    /^[a-z]\.\s+/i.test(content) ||
+    /^\d+\.\s+/.test(content)
 
   return {
     content,
@@ -58,8 +71,129 @@ function parseLine(line: string): Line {
     isHeader,
     isCodeBlock,
     isListItem,
+    isNumberedSection,
+    isBulletPoint,
     parent: undefined,
   }
+}
+
+/**
+ * Split a line with multiple bullet points into separate lines
+ * Handles cases where multiple bullets are on the same line
+ */
+function splitMultipleBullets(line: string): string[] {
+  // Skip standard cases where there are no multiple bullets or tabs
+  if (!line.includes('\t▪') && !line.includes('\t-') && !line.match(/\t\d+\./)) {
+    return [line]
+  }
+
+  // Get the leading whitespace to preserve indentation
+  const leadingWhitespace = line.match(/^(\s*)/)?.[1] || ''
+  const content = line.slice(leadingWhitespace.length)
+
+  // Detect if this line contains multiple section headers with numbers (like "1.", "2.")
+  const containsMultipleSections = (content.match(/\d+\.\s+/g) || []).length > 1
+
+  // Detect if this line contains bullet points
+  const containsBullets = content.includes('▪') || content.includes('-')
+
+  // If this line contains both numbered sections and bullets, we need special handling
+  if (containsMultipleSections && containsBullets) {
+    const results: string[] = []
+
+    // Extract all numbered sections using regex
+    const sectionMatches = Array.from(content.matchAll(/(\d+\.\s+[^▪\d\t]+)/g))
+
+    if (sectionMatches && sectionMatches.length > 0) {
+      const sections: { index: number; text: string; number: number }[] = sectionMatches.map(
+        (match) => ({
+          index: match.index || 0,
+          text: match[1].trim(),
+          number: parseInt(match[1]),
+        })
+      )
+
+      // Sort sections by their position in the text
+      sections.sort((a, b) => a.index - b.index)
+
+      // Find the boundaries of each section in the original content
+      const sectionBoundaries: { start: number; end: number; text: string }[] = sections.map(
+        (section, idx) => {
+          const start = section.index
+          const end = idx < sections.length - 1 ? sections[idx + 1].index : content.length
+          return {
+            start,
+            end,
+            text: section.text,
+          }
+        }
+      )
+
+      // For each section, extract its bullets
+      for (const section of sectionBoundaries) {
+        // Add the section header
+        results.push(`${leadingWhitespace}\t${section.text}`)
+
+        // Get the content for this section
+        const sectionContent = content.substring(section.start, section.end)
+
+        // Find all bullets in this section
+        const bulletMatches = Array.from(sectionContent.matchAll(/[▪-]\s+([^\t▪-]+)/g))
+
+        // Add each bullet with proper indentation
+        for (const bulletMatch of bulletMatches) {
+          if (bulletMatch[1] && bulletMatch[1].trim()) {
+            results.push(`${leadingWhitespace}\t\t▪\t${bulletMatch[1].trim()}`)
+          }
+        }
+      }
+
+      if (results.length > 0) {
+        return results
+      }
+    }
+  }
+
+  // For lines with tab-separated bullets but no section numbers
+  if (containsBullets && content.includes('\t▪')) {
+    // Split by tab followed by bullet
+    const parts = content.split(/\t▪/)
+
+    // Return each part as a separate line, preserving indentation
+    return parts
+      .map((part, index) => {
+        if (index === 0) {
+          // First part is the main content
+          return leadingWhitespace + part
+        } else {
+          // Add bullet marker for other parts
+          return leadingWhitespace + '\t▪ ' + part.trim()
+        }
+      })
+      .filter((line) => line.trim())
+  }
+
+  // Generic approach for tab-separated content
+  const segments = content.split(/\t(?=[▪-]|\d+\.)/)
+
+  // Process each segment to ensure proper formatting
+  return segments
+    .map((segment) => {
+      const trimmed = segment.trim()
+
+      // Ensure bullet points have proper spacing
+      if (/^[▪-][^\s]/.test(trimmed)) {
+        return leadingWhitespace + trimmed.replace(/^([▪-])/, '$1 ')
+      }
+
+      // Ensure numbered items have proper spacing
+      if (/^\d+\.[^\s]/.test(trimmed)) {
+        return leadingWhitespace + trimmed.replace(/^(\d+\.)/, '$1 ')
+      }
+
+      return leadingWhitespace + trimmed
+    })
+    .filter((line) => line.trim())
 }
 
 /**
@@ -74,32 +208,28 @@ function buildHierarchy(lines: Line[]): Line[] {
   const result = [...lines]
 
   // Track the most recent header at each level
-  // headersAtLevel[0] = H1, headersAtLevel[1] = H2, etc.
   const headersAtLevel: number[] = []
 
-  // Track section headers (headings with numbers like "1. Title")
-  const sectionHeaders: Set<number> = new Set()
+  // Track the current parent for numbered sections
+  let currentParent = -1
+  let lastNumberedSection = -1
+  let lastNumberedSectionIndent = -1
 
-  let lastParentAtLevel: number[] = [-1]
-  let inCodeBlock = false
-  let codeBlockParent: number | undefined = undefined
-  let currentSection = -1
-
-  // Store last heading seen
-  let lastHeadingIndex = -1
-  let lastHeadingLevel = 0
-
-  // First pass - identify numbered section headers
+  // First pass - identify headers and their levels
   for (let i = 0; i < result.length; i++) {
     const line = result[i]
-    const content = line.content.trim()
-    if (line.isHeader && /^#+\s+\d+\./.test(content)) {
-      const level = content.match(/^#+/)?.[0].length ?? 1
-      sectionHeaders.add(i)
+    if (line.isHeader) {
+      const match = line.content.match(/^(#+)/)
+      if (match) {
+        const level = match[0].length
+        headersAtLevel[level - 1] = i
+        // Clear deeper levels
+        headersAtLevel.length = level
+      }
     }
   }
 
-  // Second pass - build hierarchy with special handling for sections
+  // Second pass - build hierarchy
   for (let i = 0; i < result.length; i++) {
     const line = result[i]
     const content = line.content.trim()
@@ -107,162 +237,54 @@ function buildHierarchy(lines: Line[]): Line[] {
     // Skip empty lines
     if (!content) continue
 
-    // Handle code blocks
-    if (line.isCodeBlock || inCodeBlock) {
-      if (!inCodeBlock) {
-        inCodeBlock = true
-        codeBlockParent = lastParentAtLevel[lastParentAtLevel.length - 1]
-      }
-      line.parent = codeBlockParent
-      if (line.isCodeBlock && inCodeBlock) {
-        inCodeBlock = false
-        codeBlockParent = undefined
-      }
-      continue
-    }
-
     // Handle headers
     if (line.isHeader) {
-      const level = content.match(/^#+/)?.[0].length ?? 1
-      lastHeadingIndex = i
-      lastHeadingLevel = level
-
-      // Check if this is a numbered header (e.g., "### 1. Context Awareness")
-      const isNumberedHeader = /^#+\s+\d+\./.test(content)
-
-      // Find the parent for this header based on heading levels
-      if (level === 1) {
-        // Top-level (H1) headings are at the root
-        line.parent = -1
-        currentSection = -1
-      } else {
-        // Subheadings (H2+) are children of the most recent header one level up
-        // For example, H2s are children of the most recent H1
-        let parentIdx = -1
-        if (level > 1 && level - 2 < headersAtLevel.length) {
-          parentIdx = headersAtLevel[level - 2] ?? -1
-        }
-        line.parent = parentIdx
-
-        // If this is a numbered header, set it as the current section
-        if (isNumberedHeader) {
-          currentSection = i
-        }
-      }
-
-      // Update the header tracking for this level
-      headersAtLevel[level - 1] = i
-
-      // Clear header tracking for all deeper levels
-      // (when we see an H2, we clear tracked H3s, H4s, etc.)
-      headersAtLevel.length = level
-
-      // Reset parent tracking at this level for content under this header
-      lastParentAtLevel = lastParentAtLevel.slice(0, level + 1)
-      lastParentAtLevel[level] = i
-
-      continue
-    }
-
-    // Special case for direct list items right after a heading
-    if (line.isListItem && i > 0 && result[i - 1].isHeader) {
-      // Parent to the previous heading
-      line.parent = i - 1
-      continue
-    }
-
-    // Special case for list items near a heading but with blank lines in between
-    if (line.isListItem && lastHeadingIndex >= 0) {
-      // Determine if this list item should be attached to the last heading
-      let shouldAttachToHeading = true
-
-      // Check if there are non-empty, non-list-item lines between
-      // the last heading and this list item
-      for (let j = lastHeadingIndex + 1; j < i; j++) {
-        const intermediateContent = result[j].content.trim()
-        if (intermediateContent && !result[j].isListItem) {
-          shouldAttachToHeading = false
-          break
-        }
-      }
-
-      if (shouldAttachToHeading) {
-        // Parent to the last heading
-        line.parent = lastHeadingIndex
+      const match = content.match(/^(#+)/)
+      if (match) {
+        const level = match[0].length
+        // Headers are children of the previous header one level up
+        line.parent = level === 1 ? -1 : headersAtLevel[level - 2]
+        currentParent = i
+        lastNumberedSection = -1
+        lastNumberedSectionIndent = -1
         continue
       }
     }
 
-    // Special case for lines that look like section content
-    // These are lines like "**Definition:**" which should be children of the section
-    if (currentSection >= 0 && /^\*\*[^*:]+:\*\*/.test(content)) {
-      line.parent = currentSection
-      lastParentAtLevel = [currentSection]
+    // Handle numbered sections
+    if (line.isNumberedSection) {
+      const currentIndent = line.indent
+
+      // If this is at the same indentation level as the last numbered section,
+      // it should have the same parent
+      if (currentIndent === lastNumberedSectionIndent && lastNumberedSection >= 0) {
+        line.parent = result[lastNumberedSection].parent
+      } else {
+        // Otherwise, it's a child of the current parent
+        line.parent = currentParent
+      }
+
+      lastNumberedSection = i
+      lastNumberedSectionIndent = currentIndent
       continue
     }
 
-    // Handle list items and content
-    const effectiveIndent = line.indent
-
-    // Check if previous line ends with a colon - this often indicates a sublist follows
-    const prevLineEndsWithColon = i > 0 && result[i - 1]?.content.trim().endsWith(':')
-
-    // Check for lettered list items (a., b., etc.)
-    const isLetteredListItem = /^[a-z]\.\s+/i.test(line.content.trim())
-
-    // Find the previous lettered list item to maintain consistent indentation
-    let prevLetteredItemIndex = -1
-    if (isLetteredListItem) {
-      for (let j = i - 1; j >= 0; j--) {
-        if (/^[a-z]\.\s+/i.test(result[j].content.trim())) {
-          prevLetteredItemIndex = j
-          break
-        }
-      }
+    // Handle bullet points
+    if (line.isBulletPoint) {
+      // Bullet points are children of the most recent numbered section
+      line.parent = lastNumberedSection >= 0 ? lastNumberedSection : currentParent
+      continue
     }
 
-    // Adjust indentation based on context
-    let adjustedIndent = effectiveIndent
-
-    // If this is the first lettered item after a colon, increase indentation
-    if (isLetteredListItem && prevLetteredItemIndex === -1 && prevLineEndsWithColon) {
-      adjustedIndent = effectiveIndent + 1
-    }
-    // If this is a subsequent lettered item, use the same indentation as the first one
-    else if (isLetteredListItem && prevLetteredItemIndex !== -1) {
-      adjustedIndent = result[prevLetteredItemIndex].indent
-      // If parent was adjusted, use that adjustment
-      if (result[prevLetteredItemIndex].parent !== undefined) {
-        line.parent = result[prevLetteredItemIndex].parent
-      }
-    }
-    // For regular list items after a colon
-    else if (line.isListItem && prevLineEndsWithColon) {
-      adjustedIndent = effectiveIndent + 1
+    // Handle other list items
+    if (line.isListItem) {
+      // Other list items are children of the current parent
+      line.parent = currentParent
+      continue
     }
 
-    // Skip parent assignment if we've explicitly set it for lettered items
-    if (!(isLetteredListItem && prevLetteredItemIndex !== -1 && line.parent !== undefined)) {
-      // Find the appropriate parent
-      while (lastParentAtLevel.length > adjustedIndent + 1) {
-        lastParentAtLevel.pop()
-      }
-
-      // Content is parented to the most recent element at the previous indentation level
-      if (effectiveIndent < lastParentAtLevel.length) {
-        line.parent = lastParentAtLevel[effectiveIndent]
-      } else {
-        // If we're in a section and this is a direct child, parent to the section
-        if (currentSection >= 0 && effectiveIndent <= 1) {
-          line.parent = currentSection
-        } else {
-          line.parent = -1
-        }
-      }
-    }
-
-    // Update parent tracking at this level
-    lastParentAtLevel[effectiveIndent + 1] = i
+    // Default case - parent to current parent
+    line.parent = currentParent
   }
 
   return result
@@ -866,19 +888,38 @@ function processYouTubeTranscriptTimestamps(text: string): string[] {
 }
 
 /**
+ * Format milliseconds timestamp to HH:MM:SS or MM:SS
+ * @param ms Timestamp in milliseconds
+ * @returns Formatted timestamp string
+ */
+function formatTimestamp(ms: number): string {
+  const totalSeconds = Math.floor(ms / 1000)
+  const hours = Math.floor(totalSeconds / 3600)
+  const minutes = Math.floor((totalSeconds % 3600) / 60)
+  const seconds = totalSeconds % 60
+
+  if (hours > 0) {
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
+  }
+  return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`
+}
+
+/**
  * Process a Limitless Pendant transcription section
  * Format: > [Speaker](#startMs=timestamp&endMs=timestamp): Text
  */
 function processLimitlessPendantTranscription(text: string): string {
   // Check if it matches the Limitless Pendant format
-  const match = text.match(/^>\s*\[(.*?)\]\(#startMs=\d+&endMs=\d+\):\s*(.*?)$/)
+  const match = text.match(/^>\s*\[(.*?)\]\(#startMs=(\d+)&endMs=\d+\):\s*(.*?)$/)
   if (!match) return text
 
   const speaker = match[1]
-  const content = match[2]
+  const startMs = parseInt(match[2], 10)
+  const content = match[3]
+  const timestamp = formatTimestamp(startMs)
 
-  // Format as simple "{Speaker}: {Content}" (no fields)
-  return `${speaker}: ${content}`
+  // Format as "{Speaker} (timestamp): {Content}"
+  return `${speaker} (${timestamp}): ${content}`
 }
 
 /**
@@ -904,6 +945,69 @@ function isLimitlessPendantTranscription(text: string): boolean {
 }
 
 /**
+ * Detect if text is in the new transcription format
+ * Format:
+ * Speaker Name
+ * 
+ * Timestamp
+ * Content
+ */
+function isNewTranscriptionFormat(text: string): boolean {
+  const lines = text.split('\n')
+  let speakerCount = 0
+  let timestampCount = 0
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (!line) continue
+
+    // Check for speaker pattern (non-empty line followed by empty line)
+    if (i < lines.length - 1 && !lines[i + 1].trim()) {
+      speakerCount++
+    }
+    // Check for timestamp pattern (line with date/time)
+    if (line.match(/(Yesterday|Today|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),\s+\d{1,2}:\d{2}\s+(AM|PM)/)) {
+      timestampCount++
+    }
+  }
+
+  // If we have multiple speakers and timestamps, it's likely this format
+  return speakerCount >= 2 && timestampCount >= 2
+}
+
+/**
+ * Process a line in the new transcription format
+ */
+function processNewTranscriptionFormat(text: string): string {
+  const lines = text.split('\n')
+  const result: string[] = []
+  let currentSpeaker = ''
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i].trim()
+    if (!line) continue
+
+    // Check if this is a speaker line (followed by empty line)
+    if (i < lines.length - 1 && !lines[i + 1].trim()) {
+      currentSpeaker = line
+      continue
+    }
+
+    // Skip timestamp lines
+    if (line.match(/(Yesterday|Today|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),\s+\d{1,2}:\d{2}\s+(AM|PM)/)) {
+      continue
+    }
+
+    // If we have a speaker, format the content
+    if (currentSpeaker) {
+      result.push(`${currentSpeaker}: ${line}`)
+    }
+  }
+
+  return result.join('\n')
+}
+
+/**
  * Convert markdown to Tana format
  *
  * Enhanced to properly indent content under headings without using Tana's heading format
@@ -914,17 +1018,30 @@ export function convertToTana(inputText: string | undefined | null): string {
 
   // Check if this is a Limitless Pendant transcription
   const isPendantTranscription = isLimitlessPendantTranscription(inputText)
+  
+  // Check if this is the new transcription format
+  const isNewTranscription = isNewTranscriptionFormat(inputText)
 
-  // Process the input for YouTube transcript timestamps
+  // Process the input for YouTube transcript timestamps and multiple bullets
   const processedLines: string[] = []
   inputText.split('\n').forEach((line) => {
-    // Check if this line contains YouTube timestamps and split it if needed
-    const segments = processYouTubeTranscriptTimestamps(line)
-    processedLines.push(...segments)
+    // First check if this line contains multiple bullet points
+    const bulletLines = splitMultipleBullets(line)
+
+    // For each bullet line, check if it has YouTube timestamps
+    bulletLines.forEach((bulletLine) => {
+      const segments = processYouTubeTranscriptTimestamps(bulletLine)
+      processedLines.push(...segments)
+    })
   })
 
   // Join the processed lines back together
-  const processedInputText = processedLines.join('\n')
+  let processedInputText = processedLines.join('\n')
+
+  // If this is the new transcription format, process it
+  if (isNewTranscription) {
+    processedInputText = processNewTranscriptionFormat(processedInputText)
+  }
 
   // Split into lines and parse
   const lines = processedInputText.split('\n').map((line) => parseLine(line))
@@ -956,73 +1073,40 @@ export function convertToTana(inputText: string | undefined | null): string {
   // Process each line to determine its indentation level
   for (let i = 0; i < hierarchicalLines.length; i++) {
     const line = hierarchicalLines[i]
-    const content = line.content.trim()
     const parentIdx = line.parent !== undefined ? line.parent : -1
+    const parentLevel = indentLevels.get(parentIdx) || 0
 
     if (line.isHeader) {
-      // Headers are indented based on their level (H1 = 0, H2 = 1, etc.)
-      const level = headerLevels.get(i) || 1
-      indentLevels.set(i, level - 1)
+      // Headers are indented based on their level
+      const match = line.content.match(/^(#+)/)
+      if (match) {
+        const level = match[0].length
+        indentLevels.set(i, level - 1)
+      }
+    } else if (line.isNumberedSection) {
+      // Numbered sections are indented one level deeper than their parent
+      indentLevels.set(i, parentLevel + 1)
+    } else if (line.isBulletPoint) {
+      // Bullet points are indented one level deeper than their parent
+      indentLevels.set(i, parentLevel + 1)
     } else {
-      // Non-header content
-      const parentLevel = indentLevels.get(parentIdx) || 0
-
-      // Special case for Limitless Pendant transcription lines
-      if (isPendantTranscription && content.startsWith('>') && content.includes('startMs=')) {
-        // Find the section header this transcription belongs to
-        let currentSectionIdx = parentIdx
-
-        // Traverse up to find the closest header
-        while (currentSectionIdx >= 0 && !headerLevels.has(currentSectionIdx)) {
-          currentSectionIdx = hierarchicalLines[currentSectionIdx].parent ?? -1
-        }
-
-        if (currentSectionIdx >= 0) {
-          // If we found a header ancestor, indent one level deeper than that header
-          const sectionLevel = indentLevels.get(currentSectionIdx) || 0
-          indentLevels.set(i, sectionLevel + 1)
-        } else {
-          // If no header ancestor found, indent one level deeper than parent
-          indentLevels.set(i, parentLevel + 1)
-        }
-      }
-      // If the parent is a header, indent properly under it
-      else if (headerLevels.has(parentIdx)) {
-        const headerLevel = headerLevels.get(parentIdx) || 1
-
-        // For list items under a header, we want to indent them to show proper hierarchy
-        if (line.isListItem) {
-          indentLevels.set(i, headerLevel) // Child list is at the header's level + 1 (same as header's indent + 1)
-        } else {
-          // Other content under headers
-          indentLevels.set(i, headerLevel)
-        }
-      } else {
-        // Otherwise, indent one level deeper than parent
-        indentLevels.set(i, parentLevel + 1)
-      }
+      // Other content is indented one level deeper than its parent
+      indentLevels.set(i, parentLevel + 1)
     }
   }
 
   // Generate output using the calculated indentation levels
   for (let i = 0; i < hierarchicalLines.length; i++) {
     const line = hierarchicalLines[i]
-    const content = line.content.trim()
+    const rawContent = line.content
+    const content = rawContent.trim()
 
     if (!content) continue
 
+    // Start with basic indent level from hierarchy
     let indentLevel = indentLevels.get(i) || 0
 
-    // Special handling for list items under H3 headers - this is a critical fix
-    if (line.isListItem && line.parent !== undefined && headerLevels.has(line.parent)) {
-      const headerLevel = headerLevels.get(line.parent) || 1
-      if (headerLevel === 3) {
-        // If parent is an H3
-        indentLevel = indentLevel + 1 // Add an extra level of indentation
-      }
-    }
-
-    // Special case for transcription lines in Limitless Pendant format
+    // Special handling for transcription lines
     if (isPendantTranscription && content.startsWith('>')) {
       // Find the closest header/section ancestor
       let currentIdx = i
@@ -1088,20 +1172,33 @@ export function convertToTana(inputText: string | undefined | null): string {
       if (isPendantTranscription && processedContent.startsWith('>')) {
         processedContent = processLimitlessPendantTranscription(processedContent)
       } else {
-        // Remove list markers of all types but preserve checkboxes
-        processedContent = processedContent.replace(/^[-*+•]\s+(?!\[[ x]\])/, '')
-        processedContent = processedContent.replace(/^[a-z]\.\s+/i, '')
-        processedContent = processedContent.replace(/^\d+\.\s+/, '')
+        // Special case: Check if this is a numeric item that should be treated as a section header
+        const isNumberedSection =
+          /^\d+\.\s+[A-Z][a-z]+/.test(processedContent) &&
+          (processedContent.toLowerCase().includes('workshop facilitation') ||
+            processedContent.toLowerCase().includes('speaking engagements') ||
+            processedContent.toLowerCase().includes('technology leadership') ||
+            processedContent.toLowerCase().includes('business strategy'))
+
+        if (isNumberedSection) {
+          // Remove the number prefix for section headers
+          processedContent = processedContent.replace(/^\d+\.\s+/, '')
+        } else {
+          // Remove list markers of all types but preserve checkboxes
+          processedContent = processedContent.replace(/^[-*+•▪]\s+(?!\[[ x]\])/, '')
+          processedContent = processedContent.replace(/^[a-z]\.\s+/i, '')
+          processedContent = processedContent.replace(/^\d+\.\s+/, '')
+        }
+
+        // Convert fields first
+        processedContent = convertFields(processedContent)
+
+        // Then convert dates
+        processedContent = convertDates(processedContent)
+
+        // Finally process inline formatting
+        processedContent = processInlineFormatting(processedContent)
       }
-
-      // Convert fields first
-      processedContent = convertFields(processedContent)
-
-      // Then convert dates
-      processedContent = convertDates(processedContent)
-
-      // Finally process inline formatting
-      processedContent = processInlineFormatting(processedContent)
     }
 
     output += `${indent}- ${processedContent}\n`

--- a/src/utils/tana-converter.ts
+++ b/src/utils/tana-converter.ts
@@ -948,7 +948,7 @@ function isLimitlessPendantTranscription(text: string): boolean {
  * Detect if text is in the new transcription format
  * Format:
  * Speaker Name
- * 
+ *
  * Timestamp
  * Content
  */
@@ -966,7 +966,11 @@ function isNewTranscriptionFormat(text: string): boolean {
       speakerCount++
     }
     // Check for timestamp pattern (line with date/time)
-    if (line.match(/(Yesterday|Today|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),\s+\d{1,2}:\d{2}\s+(AM|PM)/)) {
+    if (
+      line.match(
+        /(Yesterday|Today|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),\s+\d{1,2}:\d{2}\s+(AM|PM)/
+      )
+    ) {
       timestampCount++
     }
   }
@@ -994,7 +998,11 @@ function processNewTranscriptionFormat(text: string): string {
     }
 
     // Skip timestamp lines
-    if (line.match(/(Yesterday|Today|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),\s+\d{1,2}:\d{2}\s+(AM|PM)/)) {
+    if (
+      line.match(
+        /(Yesterday|Today|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday),\s+\d{1,2}:\d{2}\s+(AM|PM)/
+      )
+    ) {
       continue
     }
 
@@ -1018,7 +1026,7 @@ export function convertToTana(inputText: string | undefined | null): string {
 
   // Check if this is a Limitless Pendant transcription
   const isPendantTranscription = isLimitlessPendantTranscription(inputText)
-  
+
   // Check if this is the new transcription format
   const isNewTranscription = isNewTranscriptionFormat(inputText)
 


### PR DESCRIPTION
## Description\n\nFixed bullet point conversion for mixed format lists where nested bullets weren't properly separated and appeared on the same line.\n\n## Changes Made\n\n- Added support for multiple bullet formats (numbers, symbols, letters)\n- Improved handling of nested bullet points\n- Added proper indentation for mixed format lists\n- Added test cases for mixed format lists\n\n## Testing\n\n- [x] Tested with mixed format lists\n- [x] Verified proper indentation\n- [x] Confirmed correct node hierarchy\n\nFixes #24