### PR TITLE
Feature: Add URL field and #swipe supertag for selected web text (#37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Tana Paste For Raycast Changelog
 
+## [2.1.0] - 2025-05-24
+
+### Added
+- The "Convert Selected Text to Tana" command now automatically adds a URL field and the #swipe supertag when text is selected from a web page.
+- The URL is placed above the selected text as a child node under the page title.
+- The page title is used as the parent node for the selection when available.
+
 ## [2.0.0] - 2025-05-07
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "icon": "command-icon.png",
   "author": "lisaross",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "license": "MIT",
   "commands": [
     {

--- a/src/selected-to-tana.tsx
+++ b/src/selected-to-tana.tsx
@@ -1,4 +1,4 @@
-import { showHUD, getSelectedText, Clipboard } from '@raycast/api'
+import { showHUD, getSelectedText, Clipboard, BrowserExtension } from '@raycast/api'
 import { convertToTana } from './utils/tana-converter'
 import { exec } from 'child_process'
 import { promisify } from 'util'
@@ -23,8 +23,39 @@ export default async function Command() {
       return
     }
 
+    // Try to get the active browser tab URL
+    let urlField = ''
+    let pageTitle = ''
+    try {
+      const tabs = await BrowserExtension.getTabs()
+      const activeTab = tabs?.find((tab) => tab.active && tab.url?.startsWith('http'))
+      if (activeTab && activeTab.url) {
+        urlField = `\nURL::${activeTab.url}`
+        // Try to get the page title
+        try {
+          pageTitle = await BrowserExtension.getContent({
+            cssSelector: 'title',
+            format: 'text',
+            tabId: activeTab.id,
+          })
+        } catch { /* ignore error */ }
+      }
+    } catch { /* ignore error */ }
+
+    // Format output: if pageTitle, use as parent node
+    let textWithUrl = selectedText + urlField
+    if (pageTitle) {
+      // Split selectedText into lines and indent each
+      const selectedLines = selectedText.split('\n').map((line) => '  ' + line)
+      // Place URL as the first child if present
+      const urlLine = urlField ? '  ' + urlField.trim() : ''
+      // Combine URL and selected text lines
+      const indented = [urlLine, ...selectedLines].filter(Boolean).join('\n')
+      textWithUrl = `# ${pageTitle} #swipe\n${indented}`
+    }
+
     // Convert to Tana format
-    const tanaOutput = convertToTana(selectedText)
+    const tanaOutput = convertToTana(textWithUrl)
 
     // Copy to clipboard
     await Clipboard.copy(tanaOutput)


### PR DESCRIPTION
## Feature: Add URL field and #swipe supertag for selected web text

- The "Convert Selected Text to Tana" command now automatically adds a URL field and the #swipe supertag when text is selected from a web page.
- The URL is placed above the selected text as a child node under the page title.
- The page title is used as the parent node for the selection when available.
- Version bumped to 2.1.0 and changelog updated.

Closes #37.